### PR TITLE
fix(actions): move github-token to env and remove changelog-file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: go-semantic-release/action@v1
         if: github.ref == 'refs/heads/main'
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          changelog-file: CHANGELOG.md
           hooks: goreleaser
           allow-initial-development-versions: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release pipeline fails to release, when setting the changelog-file. There was also an error that the GITHUB_TOKEN was missing, so moved the github-token to env instead.