### PR TITLE
feat: support spawn-or-focus scratch command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,10 @@
 //
 // The scratch is the command to move a window to the scratchpad workspace,
 // or show a window from the scratchpad workspace.
+// Added in v0.3.0: spawn-or-focus [app-id]
+// Using the spawn-or-focus [app-id] will either spawn a specific app, or focus it if it's already open.
 //
-//	Usage: nirimgr scratch [move|show]
+//	Usage: nirimgr scratch [move|show|spawn-or-focus [app-id]]
 package cmd
 
 import (

--- a/examples/config.json
+++ b/examples/config.json
@@ -80,5 +80,37 @@
         }
       }
     }
-  ]
+  ],
+  "spawnOrFocus": {
+    "commands": {
+      "special-term": [
+        "alacritty",
+        "--class",
+        "special-term",
+        "-e",
+        "zellij",
+        "-l",
+        "default"
+      ],
+      "special-btop": ["alacritty", "--class", "special-btop", "-e", "btop"],
+      "Slack": ["/usr/bin/slack"],
+      "deezer": ["flatpak", "run", "dev.aunetx.deezer"]
+    },
+    "rules": {
+      "match": [
+        {
+          "appId": "special-term"
+        },
+        {
+          "appId": "special-btop"
+        },
+        {
+          "appId": "Slack"
+        },
+        {
+          "appId": "deezer"
+        }
+      ]
+    }
+  }
 }

--- a/internal/connection/connection.go
+++ b/internal/connection/connection.go
@@ -155,6 +155,37 @@ func PerformRequest(req models.NiriRequest) (<-chan models.Response, error) {
 	return stream, nil
 }
 
+// ListWindows returns the current list of windows from Niri IPC.
+func ListWindows() ([]*models.Window, error) {
+	response, _ := PerformRequest(models.Windows)
+
+	resp := <-response
+
+	var windows []*models.Window
+
+	if err := json.Unmarshal(resp.Ok["Windows"], &windows); err != nil {
+		return nil, fmt.Errorf("could not unmarshal windows")
+	}
+	return windows, nil
+}
+
+// ListWorkspaces returns the current list of workspaces from Niri IPC.
+func ListWorkspaces() ([]*models.Workspace, error) {
+	response, err := PerformRequest(models.Workspaces)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := <-response
+
+	var workspaces []*models.Workspace
+	if err := json.Unmarshal(resp.Ok["Workspaces"], &workspaces); err != nil {
+		return nil, err
+	}
+
+	return workspaces, nil
+}
+
 // structToMap converts a go struct to a map.
 func structToMap(a any) (map[string]any, error) {
 	var m map[string]any

--- a/models/models.go
+++ b/models/models.go
@@ -3,6 +3,7 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"regexp"
 )
@@ -55,6 +56,8 @@ type Config struct {
 	//
 	// NOTE: The named workspace must be defined in niri config.
 	ScratchpadWorkspace string `json:"scratchpadWorkspace,omitempty"`
+	// SpawnOrFocus defines the configuration for the spawn-or-focus command.
+	SpawnOrFocus SpawnOrFocus `json:"spawnOrFocus,omitempty"`
 }
 
 // GetRules returns the configured rules.
@@ -64,6 +67,22 @@ func (c *Config) GetRules() []Rule {
 	var rules []Rule
 	rules = append(rules, c.Rules...)
 	return rules
+}
+
+// SpawnOrFocus defines the rules and commands to run for the spawn-or-focus command.
+type SpawnOrFocus struct {
+	Rules []Rule `json:"rules,omitempty"`
+	// Command is the command to spawn for the spawnOrFocus command.
+	Commands map[string][]string `json:"commands,omitempty"`
+}
+
+// Command returns the specified command to run for the given key.
+func (s *SpawnOrFocus) Command(key string) ([]string, error) {
+	command, ok := s.Commands[key]
+	if !ok {
+		return nil, fmt.Errorf("could not read command for %s", key)
+	}
+	return command, nil
 }
 
 // Match is used to match a window.


### PR DESCRIPTION
Add support for spawning or focusing an app with key-binds.

Add configuration for `spawnOrFocus` containing `commands` and `rules`.
- The `commands` is a map keyed by the app-id: ["command", "to", "run"]. The command is passed to niri as is. The rules contains the window rules for which app-id to match the command to.

Update README with new additions.