### PR TITLE
feat: make scratchpad configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,12 +249,18 @@ Example configuration (see: [config.json](./examples/config.json)):
         }
       ]
     }
+  },
+  // Configure actions to be run on the scratchpad window that was shown.
+  "showScratchpadActions": {
+    // Always center the shown scratchpad window.
+    "CenterWindow": {}
   }
 }
 ```
 
-- Added in v0.2.0: Rule type - The new rule type defines if the rule should apply to a window or a workspace.
-- Added in v0.3.0: spawn-or-focus - The new scratch command supports spawning defined apps, or focusing them if they're already running.
+- Added in v0.2.0: Configuration: Rule type - The new rule type defines if the rule should apply to a window or a workspace.
+- Added in v0.3.0: Scratch command: spawn-or-focus - The new scratch command supports spawning defined apps, or focusing them if they're already running.
+- Added in v0.4.0: Configuration: Add new configuration showScratchpadActions, i.e. define actions to be performed on the shown scratchpad window.
 
 The rules are the same as the `window-rule` in Niri configuration. Currently we only match the window on a given title or app-id.
 Then specify which action you want to do with the matched window. In the example above, the gnome calculator

--- a/cmd/scratch.go
+++ b/cmd/scratch.go
@@ -120,6 +120,17 @@ func showScratchpad() {
 			},
 		}
 
+		// If we have actions, append them to the list.
+		if len(config.Config.ShowScratchpadActions) > 0 {
+			for _, action := range actions.ParseRawActions(config.Config.ShowScratchpadActions) {
+				a := actions.HandleDynamicIDs(action, models.PossibleKeys{
+					ID:       window.ID,
+					WindowID: window.ID,
+				})
+				actionList = append(actionList, a)
+			}
+		}
+
 		for _, action := range actionList {
 			connection.PerformAction(action)
 		}

--- a/examples/config.json
+++ b/examples/config.json
@@ -112,5 +112,8 @@
         }
       ]
     }
+  },
+  "showScratchpadActions": {
+    "CenterWindow": {}
   }
 }

--- a/models/models.go
+++ b/models/models.go
@@ -58,6 +58,11 @@ type Config struct {
 	ScratchpadWorkspace string `json:"scratchpadWorkspace,omitempty"`
 	// SpawnOrFocus defines the configuration for the spawn-or-focus command.
 	SpawnOrFocus SpawnOrFocus `json:"spawnOrFocus,omitempty"`
+	// ShowScratchpadActions lists actions that should be performed on the shown scratchpad window.
+	//
+	// The `scratch show` command will always run MoveWindowToWorkspace and FocusWindow, but in addition can perform the following actions,
+	// e.g. if you want to center the window or resize it or something.
+	ShowScratchpadActions map[string]json.RawMessage `json:"showScratchpadActions,omitempty"`
 }
 
 // GetRules returns the configured rules.


### PR DESCRIPTION
Add new configuration for the scratch show command, showScratchpadActions. These actions are performed on the window that was shown from the scratchpad workspace. This is in addition to the default actions of MoveWindowToWorkspace and FocusWindow.