### PR TITLE
feat: support conditional actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,11 @@ Example configuration (see: [config.json](./examples/config.json)):
     "WindowUrgencyChanged": {
       // Any actions you want to do when the event happens.
       // In this example, when a WindowUrgencyChanged event happens, we want to focus the urgent window, and unset the window urgency.
-      "FocusWindow": {},
+      "FocusWindow": {
+        // Only focus the window if the event's urgent field is true.
+        // If the window urgency is unset, we won't focus the window.
+        "when": "event.Urgent == true"
+      },
       "UnsetWindowUrgent": {}
     }
   }
@@ -272,6 +276,8 @@ Example configuration (see: [config.json](./examples/config.json)):
 - Added in v0.3.0: Scratch command: spawn-or-focus - The new scratch command supports spawning defined apps, or focusing them if they're already running.
 - Added in v0.4.0: Configuration: Add new configuration showScratchpadActions, i.e. define actions to be performed on the shown scratchpad window.
 - Added in v0.5.0: Listen on custom events and perform actions on the event target, such as window/workspace.
+- Added in v0.6.0: Conditional actions: In the custom events configuration, we can now add a "when" condition to the action, and run the action only if the condition
+  evaluates to true.
 
 The rules are the same as the `window-rule` in Niri configuration. Currently we only match the window on a given title or app-id.
 Then specify which action you want to do with the matched window. In the example above, the gnome calculator
@@ -293,6 +299,9 @@ focus the urgent window, and unset the window urgency.
 
 _NOTE_: This addition is just a simple _listen to this event and perform that action on the target_, i.e. there are no conditions that can be applied to
 the action. E.g. Only focus the window if the `WindowUrgencyChanged` sets the urgency to `true`. The focus will also happen when the urgency is set to `false`.
+
+Since v0.6.0 you can add a condition to the custom events' actions. I.e. perform the action only when the "when"-condition evaluates to true.
+We use the [expr-lang](https://expr-lang.org/docs/getting-started) to evaluate the expression. You can see the supported conditions [here](https://expr-lang.org/docs/language-definition).
 
 Please feel free to open a PR if you have other thoughts what we could do with nirimgr.
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ to open an [issue](https://github.com/soderluk/nirimgr/issues/new).
 
 ---
 
-Q: Why not create this in Rust?
+Q: Why not write this in Rust?
 
-A: Because I need to improve my Golang knowledge, and this was a great opportunity for me to dive a bit deeper into
+A: Because I need to improve my Golang knowledge (for work), and this was a great opportunity for me to dive a bit deeper into
 the language, as well as learn a bit more on the Niri IPC and how it works.
 
 # Installation
@@ -132,7 +132,10 @@ Example configuration (see: [config.json](./examples/config.json)):
       ],
       "actions": {
         // Focus the workspace.
-        "FocusWorkspace": {},
+        "FocusWorkspace": {
+          // Only focus when the workspace name is "work"
+          "when": "model.Name == 'work'"
+        },
         // Move the workspace to the monitor on the right.
         // I.e. we always want to move our work workspace to the "main" screen, if it exists.
         "MoveWorkspaceToMonitorRight": {}
@@ -264,7 +267,7 @@ Example configuration (see: [config.json](./examples/config.json)):
       "FocusWindow": {
         // Only focus the window if the event's urgent field is true.
         // If the window urgency is unset, we won't focus the window.
-        "when": "event.Urgent == true"
+        "when": "model.Urgent == true"
       },
       "UnsetWindowUrgent": {}
     }
@@ -277,7 +280,9 @@ Example configuration (see: [config.json](./examples/config.json)):
 - Added in v0.4.0: Configuration: Add new configuration showScratchpadActions, i.e. define actions to be performed on the shown scratchpad window.
 - Added in v0.5.0: Listen on custom events and perform actions on the event target, such as window/workspace.
 - Added in v0.6.0: Conditional actions: In the custom events configuration, we can now add a "when" condition to the action, and run the action only if the condition
-  evaluates to true.
+  evaluates to true. This also applies for the matching actions in the rules. **NOTE**: The condition _must_ start with `model.`, i.e. `"when": "model.ID == 1"`.
+  where the `model` refers to the `Window` model when matching `"type": "window"`, `Workspace` model when matching `"type": "workspace"`,
+  or the event model when listening on custom events.
 
 The rules are the same as the `window-rule` in Niri configuration. Currently we only match the window on a given title or app-id.
 Then specify which action you want to do with the matched window. In the example above, the gnome calculator
@@ -300,8 +305,9 @@ focus the urgent window, and unset the window urgency.
 _NOTE_: This addition is just a simple _listen to this event and perform that action on the target_, i.e. there are no conditions that can be applied to
 the action. E.g. Only focus the window if the `WindowUrgencyChanged` sets the urgency to `true`. The focus will also happen when the urgency is set to `false`.
 
-Since v0.6.0 you can add a condition to the custom events' actions. I.e. perform the action only when the "when"-condition evaluates to true.
+Since v0.6.0 you can add a condition to the actions. I.e. perform the action only when the `"when"`-condition evaluates to true.
 We use the [expr-lang](https://expr-lang.org/docs/getting-started) to evaluate the expression. You can see the supported conditions [here](https://expr-lang.org/docs/language-definition).
+Note that the `model` is required when writing the condition, i.e. `"when": "model.Name == 'work'"` which refers to the matching window/workspace/event.
 
 Please feel free to open a PR if you have other thoughts what we could do with nirimgr.
 
@@ -396,10 +402,3 @@ the most notable being [niri-float-sticky](https://github.com/probeldev/niri-flo
 The goroutine handling of the event stream felt like a better approach than I had before, so thanks to the author for a great library!
 
 The `nirimgr scratch spawn-or-focus [app-id]` is heavily inspired by the discussion [here](https://github.com/YaLTeR/niri/discussions/329#discussioncomment-13378697)
-
-# Known issues
-
-**_Note_**: The below has been worked around by manually focusing the moved window.
-
-There seems to be an [issue](https://github.com/YaLTeR/niri/issues/1805) with niri that it doesn't respect the `focus true/false` when moving a window.
-And here's the [PR](https://github.com/YaLTeR/niri/pull/1820) to fix it (as of now, it hasn't been yet merged.)

--- a/events/events.go
+++ b/events/events.go
@@ -19,8 +19,6 @@ import (
 
 // Run starts listening on the event stream, and handle the events.
 //
-// Currently we only handle a few events, `WindowsChanged`, `WindowOpenedOrChanged` and `WindowClosed`.
-// If you need to handle more events, add them in the switch statement.
 // Initially the thought was to support the "Dynamic open-float script, for Bitwarden and other windows that set title/app-id late":
 // https://github.com/YaLTeR/niri/discussions/1599
 // But it doesn't stop us from handling other types of events as well.
@@ -73,8 +71,8 @@ func Run() {
 			// Any events we're not specifically listening to, let's check if there are any configured events.
 			if ev != nil {
 				// Handle the event if it exists in the map
-				if acts, exists := listenToEvents[ev.GetName()]; exists {
-					for actionName, actionConfig := range acts {
+				if actionConfigs, exists := listenToEvents[ev.GetName()]; exists {
+					for actionName, actionConfig := range actionConfigs {
 						rawAction := map[string]json.RawMessage{
 							actionName: actionConfig.Params,
 						}
@@ -89,7 +87,11 @@ func Run() {
 								a = actions.HandleDynamicIDs(a, possibleKeys)
 								connection.PerformAction(a)
 							} else {
-								slog.Debug("Not doing action", slog.String("name", actionName), slog.Bool("EvaluateCondition", evaluationResult))
+								slog.Debug(
+									"Not performing action",
+									slog.String("name", actionName),
+									slog.Bool("EvaluateCondition", evaluationResult),
+								)
 							}
 						}
 					}
@@ -166,7 +168,7 @@ func matchWindowAndPerformActions(window *models.Window, existingWindows map[uin
 
 	matchedBefore := window.Matched
 	window.Matched = false
-	var rawActions map[string]json.RawMessage
+	var actionConfigs map[string]models.ActionConfig
 	for _, r := range config.Config.GetRules() {
 		if r.Type != "window" && r.Type != "" {
 			continue
@@ -174,19 +176,32 @@ func matchWindowAndPerformActions(window *models.Window, existingWindows map[uin
 		if r.WindowMatches(*window) {
 			window.Matched = true
 			if len(r.Actions) > 0 {
-				rawActions = r.Actions
+				actionConfigs = r.Actions
 			}
 			break
 		}
 	}
 	if window.Matched && !matchedBefore {
-		for _, a := range ActionsFromRaw(rawActions) {
-			// Set the action IDs dynamically here.
-			a = actions.HandleDynamicIDs(a, models.PossibleKeys{
-				ID:       window.ID,
-				WindowID: window.ID,
-			})
-			connection.PerformAction(a)
+		for actionName, actionConfig := range actionConfigs {
+			rawAction := map[string]json.RawMessage{
+				actionName: actionConfig.Params,
+			}
+			for _, a := range ActionsFromRaw(rawAction) {
+				// If we have a condition defined, evaluate it, and perform the action if it evaluates to true.
+				evaluationResult, err := EvaluateCondition(actionConfig.When, window)
+				if err != nil {
+					slog.Error("Error in EvaluateCondition", slog.Any("error", err))
+				}
+				if evaluationResult {
+					a = actions.HandleDynamicIDs(a, models.PossibleKeys{
+						ID:       window.ID,
+						WindowID: window.ID,
+					})
+					connection.PerformAction(a)
+				} else {
+					slog.Debug("Not doing action", slog.String("name", actionName), slog.Bool("EvaluateCondition", evaluationResult))
+				}
+			}
 		}
 	}
 }
@@ -202,7 +217,7 @@ func matchWorkspaceAndPerformActions(workspace *models.Workspace, existingWorksp
 	matchedBefore := workspace.Matched
 
 	workspace.Matched = false
-	var rawActions map[string]json.RawMessage
+	var actionConfigs map[string]models.ActionConfig
 	for _, r := range config.Config.GetRules() {
 		if r.Type != "workspace" {
 			continue
@@ -210,27 +225,41 @@ func matchWorkspaceAndPerformActions(workspace *models.Workspace, existingWorksp
 		if r.WorkspaceMatches(*workspace) {
 			workspace.Matched = true
 			if len(r.Actions) > 0 {
-				rawActions = r.Actions
+				actionConfigs = r.Actions
 			}
 			break
 		}
 	}
 	if workspace.Matched && !matchedBefore {
-		for _, a := range ActionsFromRaw(rawActions) {
-			// Set the Action IDs dynamically here.
-			// Note that for the reference, only one is actually applied, in the order:
-			// ID, Index, Name.
-			// The IDs are only set if the action has the field.
-			a = actions.HandleDynamicIDs(a, models.PossibleKeys{
-				ID:             workspace.ID,
-				ActiveWindowID: workspace.ActiveWindowID,
-				Reference: models.ReferenceKeys{
-					ID:    workspace.ID,
-					Index: workspace.Idx,
-					Name:  workspace.Name,
-				},
-			})
-			connection.PerformAction(a)
+		for actionName, actionConfig := range actionConfigs {
+			rawAction := map[string]json.RawMessage{
+				actionName: actionConfig.Params,
+			}
+			for _, a := range ActionsFromRaw(rawAction) {
+				// If we have a condition defined, evaluate it, and perform the action if it evaluates to true.
+				evaluationResult, err := EvaluateCondition(actionConfig.When, workspace)
+				if err != nil {
+					slog.Error("Error in EvaluateCondition", slog.Any("error", err))
+				}
+				if evaluationResult {
+					a = actions.HandleDynamicIDs(a, models.PossibleKeys{
+						ID:             workspace.ID,
+						ActiveWindowID: workspace.ActiveWindowID,
+						Reference: models.ReferenceKeys{
+							ID:    workspace.ID,
+							Index: workspace.Idx,
+							Name:  workspace.Name,
+						},
+					})
+					connection.PerformAction(a)
+				} else {
+					slog.Debug(
+						"Not performing action",
+						slog.String("name", actionName),
+						slog.Bool("EvaluateCondition", evaluationResult),
+					)
+				}
+			}
 		}
 	}
 }
@@ -255,11 +284,12 @@ func FromRegistry(name string, data []byte) Event {
 	return event
 }
 
-// EvaluateCondition evaluates the given condition on the given event.
+// EvaluateCondition evaluates the given condition on the given model.
 //
-// If the event is a "WindowUrgencyChanged" event, we know that it has a field called Urgent, so
-// the condition could be "event.Urgent == true" to run an action only when the event urgency is set.
-func EvaluateCondition(condition string, event Event) (bool, error) {
+// If the model is a "WindowUrgencyChanged" event, we know that it has a field called Urgent, so
+// the condition could be "model.Urgent == true" to run an action only when the event urgency is set.
+// Note: The model can be an event, action, window, workspace or any other model.
+func EvaluateCondition(condition string, model any) (bool, error) {
 	slog.Debug("EvaluateCondition", slog.String("condition", condition))
 	// We always evaluate empty conditions to true.
 	if condition == "" {
@@ -267,9 +297,9 @@ func EvaluateCondition(condition string, event Event) (bool, error) {
 	}
 
 	env := map[string]any{
-		"event": event,
+		"model": model,
 	}
-	slog.Debug("EvaluateCondition", slog.Any("event", event))
+	slog.Debug("EvaluateCondition", slog.Any("model", model))
 	program, err := expr.Compile(condition, expr.Env(env))
 	if err != nil {
 		return false, fmt.Errorf("invalid condition '%s': %w", condition, err)

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -119,14 +119,14 @@ func TestUpdateWorkspaceMatched_MatchAndAction(t *testing.T) {
 func TestEvaluateCondition(t *testing.T) {
 	t.Run("pass", func(t *testing.T) {
 		event := WindowClosed{EName: EName{"WindowClosed"}, ID: 1}
-		got, _ := EvaluateCondition("event.ID == 1", event)
+		got, _ := EvaluateCondition("model.ID == 1", event)
 		be.True(t, got)
-		got, _ = EvaluateCondition("event.ID == 2", event)
+		got, _ = EvaluateCondition("model.ID == 2", event)
 		be.True(t, !got)
 	})
 	t.Run("with error", func(t *testing.T) {
 		event := WindowFocusChanged{EName: EName{"WindowFocusChanged"}, ID: 2}
-		_, err := EvaluateCondition("event.Urgent == true", event)
+		_, err := EvaluateCondition("model.Urgent == true", event)
 		be.Err(t, err)
 	})
 }

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/nalgeon/be"
 	"github.com/soderluk/nirimgr/config"
 	"github.com/soderluk/nirimgr/models"
 )
@@ -113,4 +114,19 @@ func TestUpdateWorkspaceMatched_MatchAndAction(t *testing.T) {
 	if !workspace.Matched {
 		t.Errorf("Expected workspace to be matched")
 	}
+}
+
+func TestEvaluateCondition(t *testing.T) {
+	t.Run("pass", func(t *testing.T) {
+		event := WindowClosed{EName: EName{"WindowClosed"}, ID: 1}
+		got, _ := EvaluateCondition("event.ID == 1", event)
+		be.True(t, got)
+		got, _ = EvaluateCondition("event.ID == 2", event)
+		be.True(t, !got)
+	})
+	t.Run("with error", func(t *testing.T) {
+		event := WindowFocusChanged{EName: EName{"WindowFocusChanged"}, ID: 2}
+		_, err := EvaluateCondition("event.Urgent == true", event)
+		be.Err(t, err)
+	})
 }

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,125 +1,135 @@
 {
-  "scratchpadWorkspace": "scratchpad",
-  "logLevel": "DEBUG",
-  "rules": [
-    {
-      "type": "workspace",
-      "match": [
+    "scratchpadWorkspace": "scratchpad",
+    "logLevel": "DEBUG",
+    "rules": [
         {
-          "name": "chat"
-        }
-      ],
-      "actions": {
-        "FocusWorkspace": {},
-        "MoveWorkspaceToMonitor": {
-          "output": "eDP-1"
-        }
-      }
-    },
-    {
-      "type": "workspace",
-      "match": [
-        {
-          "name": "work",
-          "output": "eDP-1"
-        }
-      ],
-      "actions": {
-        "FocusWorkspace": {},
-        "MoveWorkspaceToMonitorRight": {}
-      }
-    },
-    {
-      "type": "window",
-      "match": [
-        {
-          "title": "Bitwarden",
-          "appId": "zen"
-        }
-      ],
-      "actions": {
-        "MoveWindowToFloating": {},
-        "SetWindowWidth": {
-          "change": {
-            "SetFixed": 400
-          }
+            "type": "workspace",
+            "match": [
+                {
+                    "name": "chat"
+                }
+            ],
+            "actions": {
+                "FocusWorkspace": {},
+                "MoveWorkspaceToMonitor": {
+                    "output": "eDP-1"
+                }
+            }
         },
-        "SetWindowHeight": {
-          "change": {
-            "SetFixed": 600
-          }
-        }
-      }
-    },
-    {
-      "type": "window",
-      "match": [
         {
-          "appId": "org.gnome.Calculator"
-        }
-      ],
-      "actions": {
-        "MoveWindowToFloating": {},
-        "MoveFloatingWindow": {
-          "x": {
-            "SetFixed": 800
-          },
-          "y": {
-            "SetFixed": 200
-          }
+            "type": "workspace",
+            "match": [
+                {
+                    "name": "work",
+                    "output": "eDP-1"
+                }
+            ],
+            "actions": {
+                "FocusWorkspace": {},
+                "MoveWorkspaceToMonitorRight": {}
+            }
         },
-        "SetWindowWidth": {
-          "change": {
-            "SetFixed": 50
-          }
+        {
+            "type": "window",
+            "match": [
+                {
+                    "title": "Bitwarden",
+                    "appId": "zen"
+                }
+            ],
+            "actions": {
+                "MoveWindowToFloating": {},
+                "SetWindowWidth": {
+                    "change": {
+                        "SetFixed": 400
+                    }
+                },
+                "SetWindowHeight": {
+                    "change": {
+                        "SetFixed": 600
+                    }
+                }
+            }
         },
-        "SetWindowHeight": {
-          "change": {
-            "SetFixed": 50
-          }
+        {
+            "type": "window",
+            "match": [
+                {
+                    "appId": "org.gnome.Calculator"
+                }
+            ],
+            "actions": {
+                "MoveWindowToFloating": {},
+                "MoveFloatingWindow": {
+                    "x": {
+                        "SetFixed": 800
+                    },
+                    "y": {
+                        "SetFixed": 200
+                    }
+                },
+                "SetWindowWidth": {
+                    "change": {
+                        "SetFixed": 50
+                    }
+                },
+                "SetWindowHeight": {
+                    "change": {
+                        "SetFixed": 50
+                    }
+                }
+            }
         }
-      }
+    ],
+    "spawnOrFocus": {
+        "commands": {
+            "special-term": [
+                "alacritty",
+                "--class",
+                "special-term",
+                "-e",
+                "zellij",
+                "-l",
+                "default"
+            ],
+            "special-btop": [
+                "alacritty",
+                "--class",
+                "special-btop",
+                "-e",
+                "btop"
+            ],
+            "Slack": ["/usr/bin/slack"],
+            "deezer": ["flatpak", "run", "dev.aunetx.deezer"]
+        },
+        "rules": {
+            "match": [
+                {
+                    "appId": "special-term"
+                },
+                {
+                    "appId": "special-btop"
+                },
+                {
+                    "appId": "Slack"
+                },
+                {
+                    "appId": "deezer"
+                }
+            ]
+        }
+    },
+    "showScratchpadActions": {
+        "CenterWindow": {}
+    },
+    "events": {
+        "WindowUrgencyChanged": {
+            "FocusWindow": {
+                "when": "event.Urgent == true"
+            },
+            "UnsetWindowUrgent": {
+                "when": "event.Urgent == true"
+            }
+        }
     }
-  ],
-  "spawnOrFocus": {
-    "commands": {
-      "special-term": [
-        "alacritty",
-        "--class",
-        "special-term",
-        "-e",
-        "zellij",
-        "-l",
-        "default"
-      ],
-      "special-btop": ["alacritty", "--class", "special-btop", "-e", "btop"],
-      "Slack": ["/usr/bin/slack"],
-      "deezer": ["flatpak", "run", "dev.aunetx.deezer"]
-    },
-    "rules": {
-      "match": [
-        {
-          "appId": "special-term"
-        },
-        {
-          "appId": "special-btop"
-        },
-        {
-          "appId": "Slack"
-        },
-        {
-          "appId": "deezer"
-        }
-      ]
-    }
-  },
-  "showScratchpadActions": {
-    "CenterWindow": {}
-  },
-  "events": {
-    "WindowUrgencyChanged": {
-      "FocusWindow": {},
-      "UnsetWindowUrgent": {}
-    }
-  }
 }

--- a/examples/config.json
+++ b/examples/config.json
@@ -10,7 +10,9 @@
                 }
             ],
             "actions": {
-                "FocusWorkspace": {},
+                "FocusWorkspace": {
+                    "when": "model.Name == 'chat'"
+                },
                 "MoveWorkspaceToMonitor": {
                     "output": "eDP-1"
                 }
@@ -125,10 +127,10 @@
     "events": {
         "WindowUrgencyChanged": {
             "FocusWindow": {
-                "when": "event.Urgent == true"
+                "when": "model.Urgent == true"
             },
             "UnsetWindowUrgent": {
-                "when": "event.Urgent == true"
+                "when": "model.Urgent == true"
             }
         }
     }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/expr-lang/expr v1.17.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/soderluk/nirimgr
 go 1.24.6
 
 require (
+	github.com/expr-lang/expr v1.17.6
 	github.com/olekukonko/tablewriter v1.0.8
 	github.com/spf13/cobra v1.9.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/expr-lang/expr v1.17.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
@@ -20,6 +20,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/nalgeon/be v0.3.0
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
 	github.com/olekukonko/ll v0.0.8 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/expr-lang/expr v1.17.6 h1:1h6i8ONk9cexhDmowO/A64VPxHScu7qfSl2k8OlINec=
+github.com/expr-lang/expr v1.17.6/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/nalgeon/be v0.3.0 h1:QsPANqEtcOD5qT2S3KAtIkDBBn8SXUf/Lb5Bi/z4UqM=
+github.com/nalgeon/be v0.3.0/go.mod h1:PMwMuBLopwKJkSHnr2qHyLcZYUTqNejN7A8RAqNWO3E=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 h1:r3FaAI0NZK3hSmtTDrBVREhKULp8oUeqLT5Eyl2mSPo=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
 github.com/olekukonko/ll v0.0.8 h1:sbGZ1Fx4QxJXEqL/6IG8GEFnYojUSQ45dJVwN2FH2fc=

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -55,17 +55,25 @@ func parseLogLevel(level string) slog.Level {
 }
 
 // SetUintField is a helper function to set a uint64 field dynamically if present.
+//
+// Note that if the field already has a value, we don't want to override it.
 func SetUintField(field reflect.Value, fieldName string, val any) {
 	f := field.FieldByName(fieldName)
 	slog.Debug("SetUintField", "field", field, "fieldName", fieldName, "value", val)
 	if f.IsValid() && f.CanSet() {
 		switch f.Kind() {
 		case reflect.Uint8:
-			f.SetUint(uint64(val.(uint8)))
+			if f.Uint() == 0 {
+				f.SetUint(uint64(val.(uint8)))
+			}
 		case reflect.Uint64:
-			f.SetUint(uint64(val.(uint64)))
+			if f.Uint() == 0 {
+				f.SetUint(uint64(val.(uint64)))
+			}
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			f.SetInt(int64(val.(int64)))
+			if f.Int() == 0 {
+				f.SetInt(int64(val.(int64)))
+			}
 		}
 	}
 }
@@ -75,6 +83,8 @@ func SetStringField(field reflect.Value, fieldName string, val string) {
 	f := field.FieldByName(fieldName)
 	slog.Debug("SetStringField", "field", field, "fieldName", fieldName, "value", val)
 	if f.IsValid() && f.CanSet() && f.Kind() == reflect.String {
-		f.SetString(val)
+		if f.String() == "" {
+			f.SetString(val)
+		}
 	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -46,6 +46,72 @@ const (
 	OverviewState NiriRequest = "OverviewState"
 )
 
+// ActionConfig adds support for conditionally run the action.
+//
+// The "when" field uses the expr module to evaluate the expression, and
+// returns a boolean for the condition.
+// An example configuration could be:
+//
+//	{
+//		"events": {
+//			"WorkspaceActivated": {
+//				"FocusWindow": {
+//					"when": "event.ID == 3",
+//					"ID": 6
+//				}
+//			}
+//		}
+//	}
+//
+// This means that when an event "WorkspaceActivated" happens, we only run the action "FocusWindow"
+// if the workspace that was activated has an ID == 3.
+type ActionConfig struct {
+	// When contains the expression we want to evaluate.
+	//
+	// "when": "event.ID == 3" for a WorkspaceActivated event, evaluates to true if
+	// the workspace that was activated has an ID: 3.
+	When string `json:"when,omitempty"`
+	// Params contains the rest of the parameters to be defined for the action.
+	//
+	// NOTE: You don't need to set "params" in your config, but just the fields, i.e. "ID": 6 instead
+	// of "Params": {"ID": 6}.
+	Params json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON overrides the unmarshaling of an ActionConfig.
+//
+// We don't want to have the "When" field present in the rawMessage.
+func (a *ActionConfig) UnmarshalJSON(data []byte) error {
+	// Unmarshal the JSON into a map
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		return err
+	}
+
+	// Extract the "when" field if it exists
+	if whenJSON, ok := rawMap["when"]; ok {
+		// Unmarshal the when value (removing quotes)
+		var whenStr string
+		if err := json.Unmarshal(whenJSON, &whenStr); err != nil {
+			return err
+		}
+		a.When = whenStr
+
+		// Remove the when field from the map
+		delete(rawMap, "when")
+	}
+
+	// Marshal the map without the when field back to JSON
+	cleanJSON, err := json.Marshal(rawMap)
+	if err != nil {
+		return err
+	}
+
+	// Store the cleaned JSON as Params
+	a.Params = json.RawMessage(cleanJSON)
+	return nil
+}
+
 // Config contains the configuration for nirimgr.
 type Config struct {
 	// LogLevel is the log level to use. One of "DEBUG", "INFO", "WARN", "ERROR" should be used. Defaults to "INFO".
@@ -64,7 +130,7 @@ type Config struct {
 	// e.g. if you want to center the window or resize it or something.
 	ShowScratchpadActions map[string]json.RawMessage `json:"showScratchpadActions,omitempty"`
 	// Events contains the event types to listen to, and the actions to run on the specified event.
-	Events map[string]map[string]json.RawMessage `json:"events,omitempty"`
+	Events map[string]map[string]ActionConfig `json:"events,omitempty"`
 }
 
 // GetRules returns the configured rules.

--- a/models/models.go
+++ b/models/models.go
@@ -238,7 +238,7 @@ type Rule struct {
 	//
 	// This is a json.RawMessage on purpose, since we need to
 	// dynamically create the action struct.
-	Actions map[string]json.RawMessage `json:"actions,omitempty"`
+	Actions map[string]ActionConfig `json:"actions,omitempty"`
 }
 
 // WindowMatches checks if the window matches the given rule.


### PR DESCRIPTION
Add support for running actions only if a condition evaluates to `true`. This applies for both custom events we're listening to, as well as the window/workspace rules actions. For an action, you can now define a `"when": "model.FIELD == value"` condition, that gets evaluated, and only if it evaluates to true, will the action be performed.
As an example:
```json
"events": {
  "WindowUrgencyChanged": {
    "FocusWindow": {
      "when": "model.Urgency == true"
    }
  }
}
```
This will listen on the WindowUrgencyChanged event, and focuses the window (whose urgency changed), but only if the urgency is set. If the urgency is unset, then this action will not be performed.