### PR TITLE
fix: add latest event

### DIFF
--- a/events/models.go
+++ b/events/models.go
@@ -191,3 +191,15 @@ type OverviewOpenedOrClosed struct {
 	// IsOpen contains the new state of the overview.
 	IsOpen bool `json:"is_open"`
 }
+
+// ConfigLoaded when the configuration was reloaded
+//
+// This will always be received when connecting to the event stream,
+// indicating the last config load attempt
+type ConfigLoaded struct {
+	// Failed indicates that the configuration couldn't be reloaded.
+	//
+	// This can happen e.g. when the config validation
+	// fails.
+	Failed bool `json:"failed"`
+}

--- a/models/models.go
+++ b/models/models.go
@@ -1,4 +1,6 @@
 // Package models contains all the necessary models for different niri objects.
+//
+// Most of these models are defined in https://docs.rs/niri-ipc/latest/niri_ipc/index.html#structs
 package models
 
 import (
@@ -56,7 +58,7 @@ const (
 //		"events": {
 //			"WorkspaceActivated": {
 //				"FocusWindow": {
-//					"when": "event.ID == 3",
+//					"when": "model.ID == 3",
 //					"ID": 6
 //				}
 //			}
@@ -68,7 +70,7 @@ const (
 type ActionConfig struct {
 	// When contains the expression we want to evaluate.
 	//
-	// "when": "event.ID == 3" for a WorkspaceActivated event, evaluates to true if
+	// "when": "model.ID == 3" for a WorkspaceActivated event, evaluates to true if
 	// the workspace that was activated has an ID: 3.
 	When string `json:"when,omitempty"`
 	// Params contains the rest of the parameters to be defined for the action.


### PR DESCRIPTION
Add the ConfigLoaded event to the models.

Add link to the niri IPC docs from where the models are defined.

Fix docs for ActionConfig. It was still using event, instead of model to define the condition.