### PR TITLE
chore: release should depend on govulncheck

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,9 @@ jobs:
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
   test:
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - lint
+      - govulncheck
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:


### PR DESCRIPTION
The release should depend on the govulncheck.